### PR TITLE
increase MAX_TRAJ_LENGTH from 100 to 200

### DIFF
--- a/rapid/ROS_common.sys
+++ b/rapid/ROS_common.sys
@@ -34,7 +34,7 @@ RECORD ROS_joint_trajectory_pt
     num duration;
 ENDRECORD
 
-CONST num MAX_TRAJ_LENGTH := 100;
+CONST num MAX_TRAJ_LENGTH := 200;
 
 ! These variables should use TestAndSet read/write protection to prevent conflicts
 PERS bool ROS_trajectory_lock := false;


### PR DESCRIPTION
this is just a workaround, a better solution would be to buffer the trajectory into a file and stream it from there:
https://github.com/ros-industrial/abb_driver/discussions/21#discussioncomment-5326179